### PR TITLE
Improved README examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ $ yarn add revas
 ```jsx
 import React from 'react'
 import { render, View, Text } from 'revas'
-import createCanvas from './some-where'
 
 render(
   <View style={{ flex: 1 }}>
@@ -46,23 +45,36 @@ render(
 )
 ```
 
-### With React Generated Canvas Element
+### Render to a canvas rendered by React
+
+If the `<canvas>` we want to `revas.render` to is rendered by React, we need to ensure that the `<canvas>` exists in the DOM before calling `revas.render`.
+
+In the following example, we make use of `React.useEffect()` to invoke `revas.render`. Since `useEffect` is asynchronous, `revas.render` will be invoked _after_ the `<canvas>` element has been rendered to the DOM and `canvasRef` has the correct reference to the element.   
 
 <a href="https://codesandbox.io/s/polished-browser-n2myg?fontsize=14&hidenavigation=1&theme=dark">
   <img alt="Open in CodeSandbox" src="https://codesandbox.io/static/img/play-codesandbox.svg">
 </a>
+   
 
 ```jsx
-import React from 'react'
+import React, { useEffect } from 'react'
 import ReactDOM from 'react-dom'
 import { render, View, Text } from 'revas'
 
 const CANVAS_ELEMENT_STYLE = { border: '1px solid black' }
 
+const MyCanvasComponent = (props) => {
+  return (
+    <View style={{ flex: 1 }}>
+      <Text style={{ fontSize: 20 }}>Revas</Text>
+    </View>
+  )
+}
+
 const App = () => {
   const canvasRef = React.useRef()
 
-  React.useEffect(() => {
+  useEffect(() => {
     render(<MyCanvasComponent />, canvasRef.current)
   }, [])
 
@@ -77,14 +89,6 @@ const App = () => {
         border="1px solid black"
       />
     </div>
-  )
-}
-
-export const MyCanvasComponent = (props) => {
-  return (
-    <View style={{ flex: 1 }}>
-      <Text style={{ fontSize: 20 }}>Revas</Text>
-    </View>
   )
 }
 

--- a/README.md
+++ b/README.md
@@ -82,11 +82,7 @@ const App = () => {
     <div className="App">
       <canvas
         ref={canvasRef}
-        id="canvas-root"
-        width="500"
-        height="500"
         style={CANVAS_ELEMENT_STYLE}
-        border="1px solid black"
       />
     </div>
   )

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ Build Apps on Canvas, with React and Flexible CSS, inspired by <code>react-canva
 
 The main difference from `react-canvas` is that it does not depend strongly on `react-dom`, so that it can run in different terminals through the `canvas` interface provided by different implementation. In addition, compared to `react-canvas`, `revas` is:
 
-  1. Support for the latest version of React for a better interactive experience under Fiber, use the latest version of Yoga for more stability
-  2. Same `View` and `Text` API as `react-native`, lower understanding cost
+1. Support for the latest version of React for a better interactive experience under Fiber, use the latest version of Yoga for more stability
+2. Same `View` and `Text` API as `react-native`, lower understanding cost
 
 In terms of performance, `react-canvas` was previously focused on smooth 60FPS interaction, because after getting rid of the constraints of DOM operations, UI drawing on canvas can be rendered faster. In terms of cross-end capabilities, it depends on the unified definition of the canvas interface, which makes it easier to migrate between platforms. When the native canvas interface is delisted or dynamic cannot be used, it is easier to migrate / downgrade to the Web.
 
@@ -25,23 +25,71 @@ In terms of performance, `react-canvas` was previously focused on smooth 60FPS i
 
 ## Install
 
-``` bash
+```bash
 $ yarn add revas
 ```
 
 ## Usage
 
+### Minimal
+
 ```jsx
 import React from 'react'
-import {render, View, Text} from 'revas'
+import { render, View, Text } from 'revas'
 import createCanvas from './some-where'
 
 render(
   <View style={{ flex: 1 }}>
     <Text style={{ fontSize: 20 }}>Revas</Text>
   </View>,
-  createCanvas()
+  document.getElementById('my-canvas'),
 )
+```
+
+### With React Generated Canvas Element
+
+<a href="https://codesandbox.io/s/polished-browser-n2myg?fontsize=14&hidenavigation=1&theme=dark">
+  <img alt="Open in CodeSandbox" src="https://codesandbox.io/static/img/play-codesandbox.svg">
+</a>
+
+```jsx
+import React from 'react'
+import ReactDOM from 'react-dom'
+import { render, View, Text } from 'revas'
+
+const CANVAS_ELEMENT_STYLE = { border: '1px solid black' }
+
+const App = () => {
+  const canvasRef = React.useRef()
+
+  React.useEffect(() => {
+    render(<MyCanvasComponent />, canvasRef.current)
+  }, [])
+
+  return (
+    <div className="App">
+      <canvas
+        ref={canvasRef}
+        id="canvas-root"
+        width="500"
+        height="500"
+        style={CANVAS_ELEMENT_STYLE}
+        border="1px solid black"
+      />
+    </div>
+  )
+}
+
+export const MyCanvasComponent = (props) => {
+  return (
+    <View style={{ flex: 1 }}>
+      <Text style={{ fontSize: 20 }}>Revas</Text>
+    </View>
+  )
+}
+
+const rootElement = document.getElementById('root')
+ReactDOM.render(<App />, rootElement)
 ```
 
 ## Components
@@ -76,7 +124,9 @@ render(
 
 ```jsx
 <ScrollView style={{ position: 'absolute', top: 0, left: 0, right: 0, bottom: 0 }}>
-  {colors.map((c, i) => <View key={i} style={{ height: 80, backgroundColor: c }} />)}
+  {colors.map((c, i) => (
+    <View key={i} style={{ height: 80, backgroundColor: c }} />
+  ))}
 </ScrollView>
 ```
 
@@ -89,4 +139,3 @@ render(
 <p align="center">
   <img src="https://user-images.githubusercontent.com/5719833/74612290-052f5900-513f-11ea-94ff-17ea50b31a50.png" width=600 />
 </p>
-


### PR DESCRIPTION
First, I want to say that this is an awesome tool you are creating. It is a tool that **absolutely** needs to exist, but it is a big task to take on so nobody has stepped up! I have been working on a canvas based app for a few months now and it has not been fun working with `react-konva`. (Which is basically the only option for React 16 and canvas.)

For the past month I have been considering creating this library myself, but knew it would be a lot to do by myself so I hadn't started yet. I am glad you took action. I'd like to support you in development of `revas`, as I think it could be the React canvas library that the world needs. 🙏 

---

In README.md, I was confused at first by `createCanvas()` and how exactly to use `render`, so after I figured it out I decided it would be good to make the example a little bit easier to understand and also to provide a second example showing how to use `render` if the target canvas is rendered in the React tree. 👍 These changes are represented in this PR.

I am open to discuss rewording the description I added to the README, and to refactoring the example code I added if it is not to your liking. Just let me know what you think!