### PR TITLE
Add devtools support

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,5 +63,8 @@
       "not dead",
       "not op_mini all"
     ]
+  },
+  "prettier": {
+    "singleQuote": true
   }
 }

--- a/src/revas/core/reconciler.ts
+++ b/src/revas/core/reconciler.ts
@@ -1,7 +1,12 @@
-import ReactReconciler from 'react-reconciler';
+import ReactReconciler, { DevToolsConfig } from 'react-reconciler';
 import { Node } from './Node';
 import { noop, now } from './utils';
 import { Container } from './Container';
+
+import pkg from '../../../package.json';
+
+const { version, name } = pkg;
+const isDev = process.env.NODE_ENV !== 'production';
 
 function checkAndRemove(parent: Node, child: Node) {
   const index = parent.children.indexOf(child);
@@ -70,7 +75,7 @@ const unused: any = {
   },
 };
 
-export default ReactReconciler({
+const RevasReconciler = ReactReconciler({
   supportsHydration: false,
   supportsPersistence: false,
   supportsMutation: true,
@@ -165,3 +170,20 @@ export default ReactReconciler({
   noTimeout: -1,
   now,
 });
+
+const devToolsConfig: DevToolsConfig<any, any> = {
+  bundleType: isDev ? 1 : 0,
+  version,
+  rendererPackageName: name,
+
+  // could not get this typed.
+  // The above `DevToolsConfig` is a generic expecting an `Instance`
+  // and `TextInstance` type, but I didn't see these declared anywhere
+
+  // @ts-ignore
+  findHostInstanceByFiber: RevasReconciler.findHostInstance,
+};
+
+RevasReconciler.injectIntoDevTools(devToolsConfig);
+
+export default RevasReconciler;


### PR DESCRIPTION
This PR:

- adds initial, rudimentary React DevTools support
- adds some initial `prettier`, to avoid any prettier enabled editors from changing the existing code style too much and causing git diff noise. It shouldn't cause an issue for non-prettier enabled editors, and the only change I could see was related to single quotes.

### Motivation

I use DevTools in web based React development quite often, for a variety of reasons: inspecting props, local reducers, values of useStates etc. Having the same tooling for Revas would be a benefit in my opinion.

### Example

_screenshot of the devtools, and adjusting a value in the `style` prop, aligning items `flex-end`_

<img width="898" alt="Screenshot 2021-02-07 at 15 20 17" src="https://user-images.githubusercontent.com/9934306/107201849-6ce65000-69f1-11eb-9986-6b7897d9b234.png">

### Known issues

The DevTools allow altering some props but not others. So, changing the `text` of a `<Card/>` does nothing. I think this is related to the DevTools just not liking ClassComponents, but this is a guess. I created a simple component like so:

```javascript
interface SomethingSimpleProps {
  text: string;
}

const SomethingSimple: React.FunctionComponent<SomethingSimpleProps> = ({
  text,
}) => {
  const onPress = React.useCallback((e) => {
    console.log('[SomethingSimple] e', e);
  }, []);

  return (
    <Touchable onPress={onPress}>
      <View>
        <Text>{text}</Text>
      </View>
    </Touchable>
  );
};
```

and you can adjust the `text` prop as you would expect.

- unlike in the ReactDom dev tools integration, you can't highlight components.
- `<Text/>` component doesn't load in the DevTools, unlike `<View/>`. I'm not entirely sure why this is, but would hazard a guess at it being a Class based component (see below)
- there's some nasty lack of typing against where the DevTools are injected. Left a note but couldn't figure it out. Sorry about that.
- DevTools can complain when it encounters Class components (https://github.com/facebook/react/issues/19765). You will see this, 

<img width="853" alt="Screenshot 2021-02-08 at 09 57 16" src="https://user-images.githubusercontent.com/9934306/107204047-21817100-69f4-11eb-86b8-7b3ba1e1d148.png">

